### PR TITLE
all handlers should be wrapped when accessing gets from  database ser…

### DIFF
--- a/apps/backend-serverless/src/handlers/clients/merchant-ui/read-data/merchant-data.ts
+++ b/apps/backend-serverless/src/handlers/clients/merchant-ui/read-data/merchant-data.ts
@@ -4,7 +4,7 @@ import { requestErrorResponse } from '../../../../utilities/responses/request-re
 import { MerchantAuthToken } from '../../../../models/clients/merchant-ui/merchant-auth-token.model.js';
 import { withAuth } from '../../../../utilities/clients/merchant-ui/token-authenticate.utility.js';
 import { MerchantService } from '../../../../services/database/merchant-service.database.service.js';
-import { PrismaClient } from '@prisma/client';
+import { Merchant, PrismaClient } from '@prisma/client';
 import { createGeneralResponse } from '../../../../utilities/clients/merchant-ui/create-general-response.js';
 import { createOnboardingResponse } from '../../../../utilities/clients/merchant-ui/create-onboarding-response.utility.js';
 import { ErrorMessage, ErrorType, errorResponse } from '../../../../utilities/responses/error-response.utility.js';
@@ -29,12 +29,19 @@ export const merchantData = Sentry.AWSLambda.wrapHandler(
             return errorResponse(ErrorType.unauthorized, ErrorMessage.unauthorized);
         }
 
-        const merchant = await merchantService.getMerchant({ id: merchantAuthToken.id });
+        let merchant: Merchant | null;
+
+        try {
+            merchant = await merchantService.getMerchant({ id: merchantAuthToken.id });
+        } catch (error) {
+            return errorResponse(ErrorType.unauthorized, ErrorMessage.databaseAccessError);
+        }
 
         if (merchant == null) {
             return errorResponse(ErrorType.notFound, ErrorMessage.unknownMerchant);
         }
 
+        // TODO: try/catch this
         const generalResponse = await createGeneralResponse(merchantAuthToken, prisma);
         const onboardingResponse = createOnboardingResponse(merchant);
 

--- a/apps/backend-serverless/src/handlers/clients/merchant-ui/write-data/reject-refund.ts
+++ b/apps/backend-serverless/src/handlers/clients/merchant-ui/write-data/reject-refund.ts
@@ -46,17 +46,29 @@ export const rejectRefund = Sentry.AWSLambda.wrapHandler(
             return errorResponse(ErrorType.badRequest, ErrorMessage.invalidRequestParameters);
         }
 
-        const refundRecord = await refundRecordService.getRefundRecord({
-            shopId: rejectRefundRequest.refundId,
-        });
+        let refundRecord: RefundRecord | null;
+
+        try {
+            refundRecord = await refundRecordService.getRefundRecord({
+                shopId: rejectRefundRequest.refundId,
+            });
+        } catch (error) {
+            return errorResponse(ErrorType.internalServerError, ErrorMessage.databaseAccessError);
+        }
 
         if (refundRecord == null) {
             return errorResponse(ErrorType.notFound, ErrorMessage.unknownRefundRecord);
         }
 
-        const merchant = await merchantService.getMerchant({
-            id: merchantAuthToken.id,
-        });
+        let merchant: Merchant | null;
+
+        try {
+            merchant = await merchantService.getMerchant({
+                id: merchantAuthToken.id,
+            });
+        } catch (error) {
+            return errorResponse(ErrorType.internalServerError, ErrorMessage.databaseAccessError);
+        }
 
         if (merchant == null) {
             return errorResponse(ErrorType.notFound, ErrorMessage.unknownMerchant);

--- a/apps/backend-serverless/src/utilities/responses/error-response.utility.ts
+++ b/apps/backend-serverless/src/utilities/responses/error-response.utility.ts
@@ -7,6 +7,7 @@ export enum ErrorType {
 }
 
 export enum ErrorMessage {
+    databaseAccessError = 'Database access error.',
     internalServerError = 'Internal server error.',
     missingBody = 'Missing body from request.',
     missingEnv = 'Missing internal configuration.',


### PR DESCRIPTION
we recently added throw wrappers on bad prisma calls, including gets. previously we just thought returning null was good enough but it wasn't. now we had to add try/catch from every handler where we called this